### PR TITLE
Add upgrade system and car selection

### DIFF
--- a/scripts/gameState.js
+++ b/scripts/gameState.js
@@ -1,0 +1,27 @@
+const defaultState = {
+  points: 0,
+  carIndex: 0,
+  upgrades: { tires: 0, turbo: 0, ecu: 0 }
+};
+
+export const cars = [
+  { name: 'Gol', color: 0xff0000, acceleration: 600, maxSpeed: 400 },
+  { name: 'Jetta', color: 0x00ff00, acceleration: 620, maxSpeed: 420 },
+  { name: 'Golf', color: 0x0000ff, acceleration: 630, maxSpeed: 430 },
+  { name: 'Voyage', color: 0xffff00, acceleration: 610, maxSpeed: 410 },
+  { name: 'Up', color: 0xff00ff, acceleration: 580, maxSpeed: 405 },
+  { name: 'Chevette', color: 0x00ffff, acceleration: 590, maxSpeed: 400 },
+  { name: 'Corsa', color: 0xffffff, acceleration: 600, maxSpeed: 415 }
+];
+
+export function loadState() {
+  const data = localStorage.getItem('dragGameState');
+  if (data) {
+    return { ...defaultState, ...JSON.parse(data) };
+  }
+  return { ...defaultState };
+}
+
+export function saveState(state) {
+  localStorage.setItem('dragGameState', JSON.stringify(state));
+}

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -2,6 +2,8 @@ import PreloadScene from './scenes/PreloadScene.js';
 import MenuScene from './scenes/MenuScene.js';
 import RaceScene from './scenes/RaceScene.js';
 import EndScene from './scenes/EndScene.js';
+import UpgradeScene from './scenes/UpgradeScene.js';
+import CarSelectScene from './scenes/CarSelectScene.js';
 
 const config = {
   type: Phaser.AUTO,
@@ -14,7 +16,7 @@ const config = {
       debug: false
     }
   },
-  scene: [PreloadScene, MenuScene, RaceScene, EndScene]
+  scene: [PreloadScene, MenuScene, RaceScene, EndScene, UpgradeScene, CarSelectScene]
 };
 
 const game = new Phaser.Game(config);

--- a/scripts/scenes/CarSelectScene.js
+++ b/scripts/scenes/CarSelectScene.js
@@ -1,0 +1,23 @@
+import { cars, loadState, saveState } from '../gameState.js';
+
+export default class CarSelectScene extends Phaser.Scene {
+  constructor() { super('carselect'); }
+
+  create() {
+    this.state = loadState();
+    const { width } = this.scale;
+    this.add.text(width / 2, 40, 'Escolher Carro', { fontSize: '24px', color: '#ffffff' }).setOrigin(0.5);
+    cars.forEach((car, i) => {
+      const y = 100 + i * 30;
+      const color = i === this.state.carIndex ? '#ffff00' : '#ffffff';
+      const text = this.add.text(width / 2, y, car.name, { fontSize: '20px', color }).setOrigin(0.5).setInteractive();
+      text.on('pointerdown', () => {
+        this.state.carIndex = i;
+        saveState(this.state);
+        this.scene.start('menu');
+      });
+    });
+    const back = this.add.text(width / 2, 100 + cars.length * 30 + 40, 'Voltar', { fontSize: '20px', color: '#ffffff' }).setOrigin(0.5).setInteractive();
+    back.on('pointerdown', () => { this.scene.start('menu'); });
+  }
+}

--- a/scripts/scenes/EndScene.js
+++ b/scripts/scenes/EndScene.js
@@ -1,20 +1,17 @@
+import { loadState } from '../gameState.js';
+
 export default class EndScene extends Phaser.Scene {
-  constructor() {
-    super('end');
-  }
+  constructor() { super('end'); }
   init(data) {
     this.finalTime = data.time || 0;
   }
   create() {
     const { width, height } = this.scale;
-    this.add.text(width / 2, height / 2 - 20, `Tempo: ${this.finalTime.toFixed(2)}s`, {
-      fontSize: '24px',
-      color: '#ffffff'
-    }).setOrigin(0.5);
-    this.add.text(width / 2, height / 2 + 20, 'Press SPACE to Menu', {
-      fontSize: '18px',
-      color: '#ffffff'
-    }).setOrigin(0.5);
+    const state = loadState();
+    this.add.text(width / 2, height / 2 - 40, `Tempo: ${this.finalTime.toFixed(2)}s`, { fontSize: '24px', color: '#ffffff' }).setOrigin(0.5);
+    this.add.text(width / 2, height / 2 - 10, '+50 Pontos!', { fontSize: '20px', color: '#ffff00' }).setOrigin(0.5);
+    this.add.text(width / 2, height / 2 + 20, `Total: ${state.points} pontos`, { fontSize: '20px', color: '#ffffff' }).setOrigin(0.5);
+    this.add.text(width / 2, height / 2 + 60, 'Pressione SPACE para Menu', { fontSize: '18px', color: '#ffffff' }).setOrigin(0.5);
     this.input.keyboard.once('keydown-SPACE', () => {
       this.scene.start('menu');
     });

--- a/scripts/scenes/MenuScene.js
+++ b/scripts/scenes/MenuScene.js
@@ -1,15 +1,19 @@
+import { cars, loadState } from '../gameState.js';
+
 export default class MenuScene extends Phaser.Scene {
-  constructor() {
-    super('menu');
-  }
+  constructor() { super('menu'); }
+
   create() {
+    this.state = loadState();
     const { width, height } = this.scale;
-    this.add.text(width / 2, height / 2, 'Press SPACE to Start', {
-      fontSize: '24px',
-      color: '#ffffff'
-    }).setOrigin(0.5);
-    this.input.keyboard.once('keydown-SPACE', () => {
-      this.scene.start('race');
-    });
+    this.add.text(width / 2, 60, 'Drag Game', { fontSize: '32px', color: '#ffffff' }).setOrigin(0.5);
+    this.add.text(width / 2, 110, `Carro: ${cars[this.state.carIndex].name}`, { fontSize: '20px', color: '#ffffff' }).setOrigin(0.5);
+    this.pointsText = this.add.text(width / 2, 140, `Pontos: ${this.state.points}`, { fontSize: '20px', color: '#ffffff' }).setOrigin(0.5);
+    const run = this.add.text(width / 2, height / 2 - 30, 'Correr', { fontSize: '24px', color: '#ffff00' }).setOrigin(0.5).setInteractive();
+    run.on('pointerdown', () => { this.scene.start('race'); });
+    const upgrade = this.add.text(width / 2, height / 2 + 10, 'Upgrade', { fontSize: '24px', color: '#ffff00' }).setOrigin(0.5).setInteractive();
+    upgrade.on('pointerdown', () => { this.scene.start('upgrade'); });
+    const changeCar = this.add.text(width / 2, height / 2 + 50, 'Trocar Carro', { fontSize: '24px', color: '#ffff00' }).setOrigin(0.5).setInteractive();
+    changeCar.on('pointerdown', () => { this.scene.start('carselect'); });
   }
 }

--- a/scripts/scenes/RaceScene.js
+++ b/scripts/scenes/RaceScene.js
@@ -1,21 +1,28 @@
+import { cars, loadState, saveState } from '../gameState.js';
+
 export default class RaceScene extends Phaser.Scene {
-  constructor() {
-    super('race');
-  }
+  constructor() { super('race'); }
+
   create() {
     const { width, height } = this.scale;
-    this.trackLength = 201; // meters
+    this.state = loadState();
+    const carData = cars[this.state.carIndex];
+    const ups = this.state.upgrades;
+    this.trackLength = 201;
     this.distance = 0;
     this.startTime = this.time.now;
 
-    this.car = this.add.rectangle(50, height / 2, 60, 20, 0xff0000);
+    this.car = this.add.rectangle(50, height / 2, 60, 20, carData.color);
     this.physics.add.existing(this.car);
     this.speed = 0;
-    this.maxSpeed = 400; // pixels per second
-    this.acceleration = 600; // per second
+    const accelBonus = 1 + 0.1 * (ups.tires + ups.turbo);
+    const speedBonus = 1 + 0.1 * ups.ecu;
+    this.maxSpeed = carData.maxSpeed * speedBonus;
+    this.acceleration = carData.acceleration * accelBonus;
     this.brakePower = 800;
     this.cursors = this.input.keyboard.createCursorKeys();
   }
+
   update(time, delta) {
     const dt = delta / 1000;
     if (this.cursors.space.isDown || this.cursors.up.isDown) {
@@ -25,7 +32,6 @@ export default class RaceScene extends Phaser.Scene {
       this.speed -= this.brakePower * dt;
       if (this.speed < 0) this.speed = 0;
     } else {
-      // natural slow down
       this.speed -= this.acceleration * dt * 0.5;
       if (this.speed < 0) this.speed = 0;
     }
@@ -35,6 +41,8 @@ export default class RaceScene extends Phaser.Scene {
 
     if (this.distance >= this.trackLength) {
       const finalTime = (time - this.startTime) / 1000;
+      this.state.points += 50;
+      saveState(this.state);
       this.scene.start('end', { time: finalTime });
     }
   }

--- a/scripts/scenes/UpgradeScene.js
+++ b/scripts/scenes/UpgradeScene.js
@@ -1,0 +1,33 @@
+import { loadState, saveState } from '../gameState.js';
+
+export default class UpgradeScene extends Phaser.Scene {
+  constructor() { super('upgrade'); }
+
+  create() {
+    this.state = loadState();
+    const { width, height } = this.scale;
+    this.add.text(width / 2, 40, 'Upgrades', { fontSize: '24px', color: '#ffffff' }).setOrigin(0.5);
+    this.pointsText = this.add.text(width / 2, 80, `Pontos: ${this.state.points}`, { fontSize: '20px', color: '#ffffff' }).setOrigin(0.5);
+    this.createUpgradeOption('Pneus (Tração)', 'tires', 0);
+    this.createUpgradeOption('Turbo/Escapamento', 'turbo', 1);
+    this.createUpgradeOption('ECU Tune', 'ecu', 2);
+    const back = this.add.text(width / 2, height - 40, 'Voltar', { fontSize: '20px', color: '#ffffff' }).setOrigin(0.5).setInteractive();
+    back.on('pointerdown', () => { saveState(this.state); this.scene.start('menu'); });
+  }
+
+  createUpgradeOption(label, key, index) {
+    const { width } = this.scale;
+    const y = 140 + index * 40;
+    const level = this.state.upgrades[key];
+    const text = this.add.text(width / 2, y, `${label}: Nivel ${level}`, { fontSize: '20px', color: '#ffffff' }).setOrigin(0.5).setInteractive();
+    text.on('pointerdown', () => {
+      const cost = 100;
+      if (this.state.points >= cost) {
+        this.state.points -= cost;
+        this.state.upgrades[key] += 1;
+        this.pointsText.setText(`Pontos: ${this.state.points}`);
+        text.setText(`${label}: Nivel ${this.state.upgrades[key]}`);
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add persistent game state with car list
- implement interactive menu with options to run, upgrade or change cars
- allow purchase of upgrades that improve acceleration or top speed
- enable car selection from a list
- reward races with points shown in the end screen

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6881827f1d8083218262a89109804946