### PR TITLE
Add simple car sprites with wheel rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Drag Game
 
 Projeto de jogo 2D de arrancada usando Phaser.js.
-Agora os carros possuem um corpo com rodas que giram durante a corrida,
-tornando a experiência mais animada mesmo sem imagens externas.
+Os carros agora são montados a partir de imagens SVG do corpo e das rodas,
+o que deixa o visual mais parecido com carros reais sem depender de fotos.
+As rodas continuam girando conforme a velocidade.
 
 ## Desenvolvimento
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Drag Game
 
 Projeto de jogo 2D de arrancada usando Phaser.js.
+Agora os carros possuem um corpo com rodas que giram durante a corrida,
+tornando a experiência mais animada mesmo sem imagens externas.
 
 ## Desenvolvimento
 

--- a/assets/sprites/car_body.svg
+++ b/assets/sprites/car_body.svg
@@ -1,0 +1,6 @@
+<svg width="128" height="40" viewBox="0 0 128 40" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="8" width="128" height="24" rx="4" fill="#ff0000"/>
+  <rect x="20" y="0" width="88" height="16" rx="3" fill="#ff5555"/>
+  <rect x="32" y="2" width="24" height="12" fill="#ffffff"/>
+  <rect x="72" y="2" width="24" height="12" fill="#ffffff"/>
+</svg>

--- a/assets/sprites/wheel.svg
+++ b/assets/sprites/wheel.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="16" cy="16" r="16" fill="#111"/>
+  <circle cx="16" cy="16" r="8" fill="#555"/>
+</svg>

--- a/scripts/scenes/PreloadScene.js
+++ b/scripts/scenes/PreloadScene.js
@@ -3,7 +3,19 @@ export default class PreloadScene extends Phaser.Scene {
     super('preload');
   }
   preload() {
-    // Assets would be loaded here
+    // Cria textura base do carro
+    const body = this.make.graphics();
+    body.fillStyle(0xffffff);
+    body.fillRect(0, 0, 120, 40);
+    body.generateTexture('carBody', 120, 40);
+    body.destroy();
+
+    // Cria textura das rodas
+    const wheel = this.make.graphics();
+    wheel.fillStyle(0x000000);
+    wheel.fillCircle(16, 16, 16);
+    wheel.generateTexture('wheel', 32, 32);
+    wheel.destroy();
   }
   create() {
     this.scene.start('menu');

--- a/scripts/scenes/PreloadScene.js
+++ b/scripts/scenes/PreloadScene.js
@@ -3,19 +3,9 @@ export default class PreloadScene extends Phaser.Scene {
     super('preload');
   }
   preload() {
-    // Cria textura base do carro
-    const body = this.make.graphics();
-    body.fillStyle(0xffffff);
-    body.fillRect(0, 0, 120, 40);
-    body.generateTexture('carBody', 120, 40);
-    body.destroy();
-
-    // Cria textura das rodas
-    const wheel = this.make.graphics();
-    wheel.fillStyle(0x000000);
-    wheel.fillCircle(16, 16, 16);
-    wheel.generateTexture('wheel', 32, 32);
-    wheel.destroy();
+    // Carrega imagens SVG do corpo e rodas do carro
+    this.load.image('carBody', 'assets/sprites/car_body.svg');
+    this.load.image('wheel', 'assets/sprites/wheel.svg');
   }
   create() {
     this.scene.start('menu');

--- a/scripts/scenes/RaceScene.js
+++ b/scripts/scenes/RaceScene.js
@@ -16,8 +16,8 @@ export default class RaceScene extends Phaser.Scene {
     this.car = this.add.container(50, height / 2);
     const body = this.add.sprite(0, 0, 'carBody').setOrigin(0.5);
     body.setTint(carData.color);
-    this.frontWheel = this.add.sprite(40, 18, 'wheel').setOrigin(0.5);
-    this.backWheel = this.add.sprite(-40, 18, 'wheel').setOrigin(0.5);
+    this.frontWheel = this.add.sprite(50, 20, 'wheel').setOrigin(0.5);
+    this.backWheel = this.add.sprite(-50, 20, 'wheel').setOrigin(0.5);
     this.car.add([body, this.frontWheel, this.backWheel]);
 
     this.speed = 0;

--- a/scripts/scenes/RaceScene.js
+++ b/scripts/scenes/RaceScene.js
@@ -12,8 +12,14 @@ export default class RaceScene extends Phaser.Scene {
     this.distance = 0;
     this.startTime = this.time.now;
 
-    this.car = this.add.rectangle(50, height / 2, 60, 20, carData.color);
-    this.physics.add.existing(this.car);
+    // Container do carro com rodas
+    this.car = this.add.container(50, height / 2);
+    const body = this.add.sprite(0, 0, 'carBody').setOrigin(0.5);
+    body.setTint(carData.color);
+    this.frontWheel = this.add.sprite(40, 18, 'wheel').setOrigin(0.5);
+    this.backWheel = this.add.sprite(-40, 18, 'wheel').setOrigin(0.5);
+    this.car.add([body, this.frontWheel, this.backWheel]);
+
     this.speed = 0;
     const accelBonus = 1 + 0.1 * (ups.tires + ups.turbo);
     const speedBonus = 1 + 0.1 * ups.ecu;
@@ -37,6 +43,10 @@ export default class RaceScene extends Phaser.Scene {
     }
 
     this.car.x += this.speed * dt;
+    const wheelRadius = 16;
+    const angleDelta = (this.speed * dt) / wheelRadius;
+    this.frontWheel.rotation += angleDelta;
+    this.backWheel.rotation += angleDelta;
     this.distance += this.speed * dt;
 
     if (this.distance >= this.trackLength) {


### PR DESCRIPTION
## Summary
- generate car body and wheel textures in the preload scene
- build the race scene using these sprites and rotate the wheels
- document that the cars now have animated wheels

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688183f8c8188321a293cc28083717a9